### PR TITLE
Add missing funder entries to Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,8 +16,11 @@ Authors@R: c(
     person("Michael", "Birrer", role = "aut"),
     person("Giovanni", "Parmigiani", role = "aut"),
     person("Curtis", "Huttenhower", role = "aut"),
-    person("Levi", "Waldron", , "lwaldron.research@gmail.com",
-    c("aut", "cre"), c(ORCID = "0000-0003-2725-0694")))
+    person("Levi", "Waldron", , "lwaldron.research@gmail.com", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0003-2725-0694")),
+    person("NCI", role = "fnd",
+           comment = c(GrantNo. = "U24CA289073"))
+  )
 Description: The curatedOvarianData package provides data for gene
     expression analysis in patients with ovarian cancer.
 Depends:


### PR DESCRIPTION
This automated PR adds missing \`fnd\` (funder) entries to the \`Authors@R\` field in \`DESCRIPTION\` based on the following grant topics set on this repository:

- U24CA289073

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#23616365054](https://github.com/waldronlab/repo-audits/actions/runs/23616365054)).